### PR TITLE
Add keyword for setting the username, password for broker auth.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,4 @@ install:
   - "pip install -r requirements.txt"
 
 script:
-  - pybot -P src tests
-
-branches:
-  only:
-    - master
-    - dev
+  - pybot -P src -e local-only tests

--- a/src/MQTTLibrary/MQTTKeywords.py
+++ b/src/MQTTLibrary/MQTTKeywords.py
@@ -15,7 +15,13 @@ class MQTTKeywords(object):
 
     def __init__(self, loop_timeout=LOOP_TIMEOUT):
         self._loop_timeout = convert_time(loop_timeout)
+        self._username = None
+        self._password = None
         #self._mqttc = mqtt.Client()
+
+    def set_username_and_password(self, username, password=None):
+        self._username = username
+        self._password = password
 
     def connect(self, broker, port=1883, client_id="", clean_session=True):
 
@@ -50,6 +56,9 @@ class MQTTKeywords(object):
         # set callbacks
         self._mqttc.on_connect = self._on_connect
         self._mqttc.on_disconnect = self._on_disconnect
+
+        if self._username:
+            self._mqttc.username_pw_set(self._username, self._password)
 
         self._mqttc.connect(broker, int(port))
 

--- a/src/MQTTLibrary/version.py
+++ b/src/MQTTLibrary/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.0'
+VERSION = '0.5.0'

--- a/tests/pubsub.txt
+++ b/tests/pubsub.txt
@@ -128,3 +128,23 @@
 | | @{messages} | Subscribe and Get Messages    | client.id=${client}   | topic=${topic}
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 0
+
+| Publish to a broker that requires username, password authentication
+| | [Tags]      | local-only
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | test
+| | Set username and password   | user1         | test1
+| | Connect     | 127.0.0.1     | 1883          | ${client}
+| | Publish     | ${topic}      | test message with username and password
+| | [Teardown]  | Disconnect
+
+| Publish to a broker that requires username, password authentication with invalid password
+| | [Tags]      | local-only
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | test
+| | Set username and password   | user1         | test
+| | Run Keyword and expect error    | The client disconnected unexpectedly
+| | ...         | Connect     | 127.0.0.1     | 1883          | ${client}
+| | [Teardown]  | Disconnect


### PR DESCRIPTION
The keyword 'set_username_and_password' stores the username and optional
password and uses the paho library's 'username_pw_set' before connecting. Fixes #2
