### PR TITLE
fix issue with subscribe async with wildcard topics

### DIFF
--- a/src/MQTTLibrary/MQTTKeywords.py
+++ b/src/MQTTLibrary/MQTTKeywords.py
@@ -199,6 +199,11 @@ class MQTTKeywords(object):
         | Length should be | ${messages} | 1 |
 
         """
+        timer_start = time.time()
+        while time.time() < timer_start + self._loop_timeout:
+            if self._subscribed:
+                break;
+            time.sleep(1)
         if not self._subscribed:
             logger.warn('Cannot listen when not subscribed to a topic')
             return []

--- a/src/MQTTLibrary/MQTTKeywords.py
+++ b/src/MQTTLibrary/MQTTKeywords.py
@@ -1,3 +1,4 @@
+from paho.mqtt.matcher import MQTTMatcher
 import paho.mqtt.client as mqtt
 import paho.mqtt.publish as publish
 import robot
@@ -6,6 +7,21 @@ import re
 
 from robot.libraries.DateTime import convert_time
 from robot.api import logger
+
+# https://github.com/eclipse/paho.mqtt.python/blob/1eec03edf39128e461e6729694cf5d7c1959e5e4/src/paho/mqtt/client.py#L250
+def topic_matches_sub(sub, topic):
+    """Check whether a topic matches a subscription.
+    For example:
+    foo/bar would match the subscription foo/# or +/bar
+    non/matching would not match the subscription non/+/+
+    """
+    matcher = MQTTMatcher()
+    matcher[sub] = True
+    try:
+        next(matcher.iter_match(topic))
+        return True
+    except StopIteration:
+        return False
 
 class MQTTKeywords(object):
 
@@ -140,6 +156,7 @@ class MQTTKeywords(object):
         logger.info('Subscribing to topic: %s' % topic)
         self._mqttc.on_subscribe = self._on_subscribe
         self._mqttc.subscribe(str(topic), int(qos))
+
         self._mqttc.on_message = self._on_message_list
 
         if seconds == 0:
@@ -311,7 +328,6 @@ class MQTTKeywords(object):
         self._disconnected = False
         self._unexpected_disconnect = False
         self._mqttc.on_disconnect = self._on_disconnect
-
         self._mqttc.disconnect()
 
         timer_start = time.time()
@@ -417,7 +433,9 @@ class MQTTKeywords(object):
             % (payload, message.topic, str(message.qos)))
         if message.topic not in self._messages:
             self._messages[message.topic] = []
-        self._messages[message.topic].append(payload)
+        for sub in self._messages:
+            if topic_matches_sub(sub, message.topic):
+                self._messages[sub].append(payload)
 
     def _on_connect(self, client, userdata, flags, rc):
         self._connected = True if rc == 0 else False

--- a/tests/connect.robot
+++ b/tests/connect.robot
@@ -5,7 +5,7 @@
 
 
 *** Variables ***
-| ${broker.uri}     | iot.eclipse.org
+| ${broker.uri}     | mqtt.eclipse.org
 | ${broker.port}    | 1883
 | ${client.id}      | test.client
 

--- a/tests/keywords.robot
+++ b/tests/keywords.robot
@@ -3,7 +3,7 @@
 | Library       | BuiltIn
 
 | *Variables*       | *Value*
-| ${broker.uri}     | iot.eclipse.org
+| ${broker.uri}     | mqtt.eclipse.org
 #| ${broker.uri}     | 127.0.0.1
 | ${broker.port}    | 1883
 | ${client.id}      | mqtt.test.client
@@ -68,8 +68,9 @@
 
 | Unsubscribe Multiple and Disconnect
 | | [Arguments] | @{topics}
-| | :FOR    | ${topic}    | IN    | @{topics}
+| | FOR    | ${topic}    | IN    | @{topics}
 | | | Unsubscribe    | ${topic}
+| | END
 | | [Teardown]  | Disconnect
 
 | Subscribe and Unsubscribe

--- a/tests/publish.robot
+++ b/tests/publish.robot
@@ -4,7 +4,7 @@
 | Test Timeout  | 30 seconds
 
 *** Variables ***
-| ${broker.uri}     | iot.eclipse.org
+| ${broker.uri}     | mqtt.eclipse.org
 | ${broker.port}    | 1883
 | ${client.id}      | mqtt.test.client
 | ${topic}          | test/mqtt_test

--- a/tests/pubsub.robot
+++ b/tests/pubsub.robot
@@ -79,7 +79,7 @@
 | | @{messages} | Subscribe and Get Messages    | client.id=${client}   | topic=${topic}
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 1
-| | Should Be Equal As Strings  | @{messages}[0]    | test message
+| | Should Be Equal As Strings  | ${messages}[0]    | test message
 
 | Subscribe with no limit, publish multiple messages and validate they are received
 | | Sleep       | 1s
@@ -93,9 +93,9 @@
 | | @{messages} | Subscribe and Get Messages    | client.id=${client}   | topic=${topic} | limit=0
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 3
-| | Should Be Equal As Strings  | @{messages}[0]    | test message1
-| | Should Be Equal As Strings  | @{messages}[1]    | test message2
-| | Should Be Equal As Strings  | @{messages}[2]    | test message3
+| | Should Be Equal As Strings  | ${messages}[0]    | test message1
+| | Should Be Equal As Strings  | ${messages}[1]    | test message2
+| | Should Be Equal As Strings  | ${messages}[2]    | test message3
 
 | Subscribe with limit
 | | Sleep       | 1s
@@ -109,12 +109,12 @@
 | | @{messages} | Subscribe and Get Messages    | client.id=${client}   | topic=${topic} | limit=1
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 1
-| | Should Be Equal As Strings  | @{messages}[0]    | test message1
+| | Should Be Equal As Strings  | ${messages}[0]    | test message1
 | | @{messages} | Subscribe and Get Messages    | client.id=${client}   | topic=${topic} | limit=2
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 2
-| | Should Be Equal As Strings  | @{messages}[0]    | test message2
-| | Should Be Equal As Strings  | @{messages}[1]    | test message3
+| | Should Be Equal As Strings  | ${messages}[0]    | test message2
+| | Should Be Equal As Strings  | ${messages}[1]    | test message3
 
 | Unsubscribe and validate no messages are received
 | | Sleep       | 1s
@@ -166,7 +166,7 @@
 | | @{messages} | Listen and Get Messages    | topic=${topic}
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 1
-| | Should Be Equal As Strings  | @{messages}[0]    | test message
+| | Should Be Equal As Strings  | ${messages}[0]    | test message
 | | [Teardown]  | Unsubscribe and Disconnect  | ${topic}
 
 | Subscribe async, publish several messages, listen for and validate they are received
@@ -184,9 +184,9 @@
 | | @{messages} | Listen and Get Messages    | topic=${topic} | limit=0
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 3
-| | Should Be Equal As Strings  | @{messages}[0]    | test message1
-| | Should Be Equal As Strings  | @{messages}[1]    | test message2
-| | Should Be Equal As Strings  | @{messages}[2]    | test message3
+| | Should Be Equal As Strings  | ${messages}[0]    | test message1
+| | Should Be Equal As Strings  | ${messages}[1]    | test message2
+| | Should Be Equal As Strings  | ${messages}[2]    | test message3
 | | [Teardown]  | Unsubscribe and Disconnect  | ${topic}
 
 | Subscribe async to multiple topics, publish several messages, listen for them and validate they are received
@@ -209,8 +209,8 @@
 | | LOG         | ${messages1}
 | | LOG         | ${messages2}
 | | Length Should Be            | ${messages1}       | 1
-| | Should Be Equal As Strings  | @{messages1}[0]    | test message2
+| | Should Be Equal As Strings  | ${messages1}[0]    | test message2
 | | Length Should Be            | ${messages2}       | 2
-| | Should Be Equal As Strings  | @{messages2}[0]    | test message1
-| | Should Be Equal As Strings  | @{messages2}[1]    | test message3
+| | Should Be Equal As Strings  | ${messages2}[0]    | test message1
+| | Should Be Equal As Strings  | ${messages2}[1]    | test message3
 | | [Teardown]  | Unsubscribe Multiple and Disconnect  | ${topic1}    | ${topic2}

--- a/tests/pubsub.robot
+++ b/tests/pubsub.robot
@@ -214,3 +214,14 @@
 | | Should Be Equal As Strings  | ${messages2}[0]    | test message1
 | | Should Be Equal As Strings  | ${messages2}[1]    | test message3
 | | [Teardown]  | Unsubscribe Multiple and Disconnect  | ${topic1}    | ${topic2}
+
+| Listen immediately after Subscribe and validate message is received
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | test/mqtt_test_sub
+| | Subscribe and Get Messages  | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker and Disconnect   | topic=${topic}    | message=test message      | qos=1
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | @{messages}= | Listen       | topic=${topic} | limit=10 | timeout=5
+| | Should Be Equal As Strings  | ${messages}[0]    | test message
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}

--- a/tests/wildcards.robot
+++ b/tests/wildcards.robot
@@ -28,7 +28,7 @@
 | | [Teardown]  | Unsubscribe and Disconnect | ${topic}
 
 | Subscribe with both single level and multi level wildcards in topic name
-| | [Tags]      | auth
+| | [Tags]      | wildcards
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | Company/+/Data/#
@@ -43,7 +43,7 @@
 | | [Teardown]  | Unsubscribe and Disconnect | ${topic}
 
 | Subscribe with multiple single level wildcards in topic name
-| | [Tags]      | auth
+| | [Tags]      | wildcards
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | Company/+/Data/+/test

--- a/tests/wildcards.robot
+++ b/tests/wildcards.robot
@@ -1,0 +1,57 @@
+| *Settings*    | *Value*
+| Resource      | keywords.robot
+| Test Timeout  | 30 seconds
+
+| *Test Cases*
+| Subscribe with a single level wildcard in topic name
+| | [Tags]      | wildcards
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | Company/+/Data
+| | ${message}  | Set Variable  | subscription test message
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker      | topic=Company/test/Data    | message=${message}      | qos=1
+| | @{messages}= | Listen       | topic=${topic} | limit=1 | timeout=1
+| | Should Be Equal As Strings  | ${messages}[0]    | ${message}
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}
+
+| Subscribe with multi level wildcard in topic name
+| | [Tags]      | wildcards
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | Company/test/Data/#
+| | ${message}  | Set Variable  | subscription test message
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker      | topic=Company/test/Data/123/abc    | message=${message}      | qos=1
+| | @{messages}= | Listen       | topic=${topic} | limit=1 | timeout=1
+| | Should Be Equal As Strings  | ${messages}[0]    | ${message}
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}
+
+| Subscribe with both single level and multi level wildcards in topic name
+| | [Tags]      | auth
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | Company/+/Data/#
+| | ${message}  | Set Variable  | subscription test message
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker      | topic=Company/test/test/123/abc    | message=messagetest
+| | Publish to MQTT Broker      | topic=Company/test/Data/123/abc    | message=messageData
+| | @{messages}= | Listen       | topic=${topic} | limit=1 | timeout=1
+| | Length should be            | ${messages}       | 1
+| | Should Be Equal As Strings  | ${messages}[0]    | messageData
+| | Should not contain          | ${messages}       | messagetest
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}
+
+| Subscribe with multiple single level wildcards in topic name
+| | [Tags]      | auth
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | Company/+/Data/+/test
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker      | topic=Company/test/Data/123/abc     | message=messageabc
+| | Publish to MQTT Broker      | topic=Company/test/Data/123/test    | message=messagetest
+| | @{messages}= | Listen       | topic=${topic} | limit=10 | timeout=5
+| | Length should be            | ${messages}       | 1
+| | Should Be Equal As Strings  | ${messages}[0]    | messagetest
+| | Should not contain          | ${messages}       | messageabc
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}


### PR DESCRIPTION
With the addition of async subscribe, we are keeping a dict of topic names and the corresponding messages received. When subscribing with a wildcard topic (eg: 'Company/+/Data'), that topic is added to dict, but when a publish is received on a matching topic, it is added to a new exact key (eg: 'Company/test/Data'). So when listening and getting messages for the wildcard topic, those were not added in the right place.

Used paho's Matcher to match whether a topic matches a wildcard subscription, and added messages to all matched topics.

Fixes #17 