### PR TITLE
Wait for subscribe to complete before listening

### DIFF
--- a/src/MQTTLibrary/MQTTKeywords.py
+++ b/src/MQTTLibrary/MQTTKeywords.py
@@ -199,6 +199,11 @@ class MQTTKeywords(object):
         | Length should be | ${messages} | 1 |
 
         """
+        timer_start = time.time()
+        while time.time() < timer_start + self._loop_timeout:
+            if self._subscribed:
+                break;
+            time.sleep(1)
         if not self._subscribed:
             logger.warn('Cannot listen when not subscribed to a topic')
             return []

--- a/tests/pubsub.robot
+++ b/tests/pubsub.robot
@@ -214,3 +214,14 @@
 | | Should Be Equal As Strings  | ${messages2}[0]    | test message1
 | | Should Be Equal As Strings  | ${messages2}[1]    | test message3
 | | [Teardown]  | Unsubscribe Multiple and Disconnect  | ${topic1}    | ${topic2}
+
+| Listen immediately after Subscribe and validate message is received
+| | ${time}     | Get Time      | epoch
+| | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
+| | ${topic}    | Set Variable  | test/mqtt_test_sub
+| | Subscribe and Get Messages  | client.id=${client}   | topic=${topic}
+| | Publish to MQTT Broker and Disconnect   | topic=${topic}    | message=test message      | qos=1
+| | Subscribe Async             | client.id=${client}   | topic=${topic}
+| | @{messages}= | Listen       | topic=${topic} | limit=10 | timeout=5
+| | Should Be Equal As Strings  | ${messages}[0]    | test message
+| | [Teardown]  | Unsubscribe and Disconnect | ${topic}

--- a/tests/wildcards.robot
+++ b/tests/wildcards.robot
@@ -28,7 +28,7 @@
 | | [Teardown]  | Unsubscribe and Disconnect | ${topic}
 
 | Subscribe with both single level and multi level wildcards in topic name
-| | [Tags]      | auth
+| | [Tags]      | wildcards
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | Company/+/Data/#
@@ -43,7 +43,7 @@
 | | [Teardown]  | Unsubscribe and Disconnect | ${topic}
 
 | Subscribe with multiple single level wildcards in topic name
-| | [Tags]      | auth
+| | [Tags]      | wildcards
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | Company/+/Data/+/test


### PR DESCRIPTION
This fixes the issue when listening right after subscribing, which if it happens too quickly doesn't let the on_subscribe callback finish and returns an error that the client isn't subscribed. Now, waiting until timeout to let the callback complete.

Fixes #15 