### PR TITLE
remove eclipse broker and use local broker for tests instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 services:
 - docker
 dist:
-- 'xenial'
+- xenial
 python:
 - '2.7'
 - '3.7'
@@ -10,17 +10,17 @@ before_install:
 - docker pull eclipse-mosquitto
 - docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
 - docker run -d -p 1883:1883 eclipse-mosquitto
-
 install:
 - pip install -r requirements.txt
 script:
 - robot -P src tests
 deploy:
+  matrix:
   - provider: pypi
-    user: "__token__"
+    user: __token__
     password:
-      secure: FNm4pha9uqgxkYHqcD9tKpaIbiw1Ue0QNJpxFBvz+ItHNHJ3KJfKHzpU45bRFpDXDjY0x9cLVDWCfAWqxCoBy6+fiBGpqfUwPR/2fgcQnelA3YdhtkQXrM47O42RuPIUPHk1ymG+v54YwWM6NbCNU8GI4NPFMAQeBOdwF8V2P6jMiUq57y5Clq7XzmHQgww23IQje9JSjsIjV45CXkeQemBV2rcZqYofaQNQwJSFtKoT1aZvT44ZRDfShoOt9JC9C7x+9ktPjO9V4T333A+FsjNTfv1QBWGsaqKybQp80rM3I3NmWTBRAswccodVEXvJAKjMxONr28CKSOPw1d2o72c7GZ0gsh8KH70SybSk9Fc2Gn1xkQPb22mhhS2KgF9RmM/jOZ8lTv0MRpHLB2Eqo9SE2B7crb4jOEY9ki4lElxPyGsOnglWUZLq1rFzQqu/nAoAooBdJvgaoPB5nEs2IElyYYP9xqjgxg1HbvqUUl8s4MsGHjiMxjY2XW8aIYz8m0tP1lt0eTBPdxRrXR7C0Bet4HfzTRI9O7A2qK2wqNNo6MW/OYjb3pAqRiWJpFFX9sTQTIiKx0FFjgqEFF2QQ9B9zVyYLlVm+8+Iojz+cLaZ/viNS7MBIZlfO7quV4HXqwHQX76hqtXjQ7r6oYBnXyZ+wA0hfcTDuMkd74Aawm0=
-    distributions: "sdist bdist_wheel"
+      secure: RS3D0zpd+1+AnwtJUpeU+XssZOSZXly1MRaU6Eo6P0ziZp1dXV+83vANPaFT7Ik7KhO/I6BuNdNrgcbLMXIi0I1Pj9ZrZq0iJ9J6PH5U2BfoXDu7XIdep5fxch5k1FMLCNl2GAnam/NFmpB0sU5+aWgpwK4o5npQ6LKWwg4BhGebFnEc4O4O8erliqoiaC1W/WvZOSLRv9WQod+Hfwbcd13tiA43i4ZkrUWGD62hB0jFaaX9CaQRcYpYzTOUe7Npbt7vw9ZavZVQ9mEklG2ttiSMfMuYuUo9lZCGssMxQP4ghTspjdMiII4rkwV0SGib4mECY/qhbzUqmFzEUe4CTrn5WOhjW8zunQbQB3+nf5w0MsxJ3/Qu1N635Acinl4njPFrxkuYOU1Wnj+Nqy6i6LBdcUVXQ1E6kSSk1g/JaqSdbae+EhpybNOKZRVfkjgG8idKotmCqQxF7JyFmdstPB9dhUcMx8q3ubjmL49ju+qI2hrIrN7Dr/Y1AWCxVJb38dSNktEG2WCc3MUgpnKPLWuzuJn+zHo9S9rLL58m/nSiejZ9XUgi3gOzrFeovAOCWSp4ZLea2c43CTBeNBhQtrKyVFzUaxyqAlJsr4oK0LapvF117eiCy1smvBuflFMb99e7qjemYRZTcV04d4RCSsDgNLy+Xxz4Vi0DTWVCdAk=
+    distributions: sdist bdist_wheel
     skip_cleanup: true
     on:
       repo: randomsync/robotframework-mqttlibrary

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ python:
 - '3.7'
 before_install:
 - docker pull eclipse-mosquitto
-- docker run -d -p 1883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
+- docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
+- docker run -d -p 1883:1883 eclipse-mosquitto
+
 install:
 - pip install -r requirements.txt
 script:
 - robot -P src tests
 deploy:
   - provider: pypi
-    user: randomsync
+    user: "__token__"
     password:
-      secure: bbHK7u+MEnJ4YifZuSsF+O5HmIMvlfHaVd1u31k2Xdbj1aYsIz1tpD+iH4mYsinJ7YpnmfJAGArSPlemLEJC2kdRcnlSRQONtpUuooLG2PPQbwIgVtJh3gpxA06L1GxVoMeRWnCfqDttFSMIs7NTxA52UtalZbER5ALXB8StHn0=
+      secure: FNm4pha9uqgxkYHqcD9tKpaIbiw1Ue0QNJpxFBvz+ItHNHJ3KJfKHzpU45bRFpDXDjY0x9cLVDWCfAWqxCoBy6+fiBGpqfUwPR/2fgcQnelA3YdhtkQXrM47O42RuPIUPHk1ymG+v54YwWM6NbCNU8GI4NPFMAQeBOdwF8V2P6jMiUq57y5Clq7XzmHQgww23IQje9JSjsIjV45CXkeQemBV2rcZqYofaQNQwJSFtKoT1aZvT44ZRDfShoOt9JC9C7x+9ktPjO9V4T333A+FsjNTfv1QBWGsaqKybQp80rM3I3NmWTBRAswccodVEXvJAKjMxONr28CKSOPw1d2o72c7GZ0gsh8KH70SybSk9Fc2Gn1xkQPb22mhhS2KgF9RmM/jOZ8lTv0MRpHLB2Eqo9SE2B7crb4jOEY9ki4lElxPyGsOnglWUZLq1rFzQqu/nAoAooBdJvgaoPB5nEs2IElyYYP9xqjgxg1HbvqUUl8s4MsGHjiMxjY2XW8aIYz8m0tP1lt0eTBPdxRrXR7C0Bet4HfzTRI9O7A2qK2wqNNo6MW/OYjb3pAqRiWJpFFX9sTQTIiKx0FFjgqEFF2QQ9B9zVyYLlVm+8+Iojz+cLaZ/viNS7MBIZlfO7quV4HXqwHQX76hqtXjQ7r6oYBnXyZ+wA0hfcTDuMkd74Aawm0=
     distributions: "sdist bdist_wheel"
     skip_cleanup: true
     on:

--- a/README.rst
+++ b/README.rst
@@ -71,11 +71,12 @@ Contributing
 
 The keywords in this library are based on some of the methods available in eclipse paho client library. If you'd like to add keywords, see instructions_ on creating/updating libraries for Robot Framework.
 
-The tests are in ``tests`` folder and make use of Robot Framework itself. They are run automatically through travis when code is pushed to a branch. Most of the tests rely on the public mqtt broker at iot.eclipse.org, but some that validate authentication rely on a local broker. You can start a local broker with the provided configuration. You can then run the tests locally::
+The tests are in ``tests`` folder and make use of Robot Framework itself. They are run automatically through travis when code is pushed to a branch. When run locally, these tests rely on locally running mqtt brokers. We need 2 running brokers, one without auth that is used by most of the tests, and the other one with auth (configuration file is provided). You'll need to start them before running the tests. You can then run the tests locally::
 
     docker pull eclipse-mosquitto
-    docker run -d -p 1883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
-    pybot -P src tests
+    docker run -d -p 1883:1883 eclipse-mosquitto
+    docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
+    robot -P src tests
 
 
 Make sure to stop the docker container when it is no longer needed.

--- a/tests/connect.robot
+++ b/tests/connect.robot
@@ -5,7 +5,7 @@
 
 
 *** Variables ***
-| ${broker.uri}     | mqtt.eclipse.org
+| ${broker.uri}     | 127.0.0.1
 | ${broker.port}    | 1883
 | ${client.id}      | test.client
 

--- a/tests/keywords.robot
+++ b/tests/keywords.robot
@@ -3,8 +3,8 @@
 | Library       | BuiltIn
 
 | *Variables*       | *Value*
-| ${broker.uri}     | mqtt.eclipse.org
-#| ${broker.uri}     | 127.0.0.1
+#| ${broker.uri}     | mqtt.eclipse.org
+| ${broker.uri}     | 127.0.0.1
 | ${broker.port}    | 1883
 | ${client.id}      | mqtt.test.client
 | ${topic}          | test/mqtt_test

--- a/tests/publish.robot
+++ b/tests/publish.robot
@@ -4,7 +4,7 @@
 | Test Timeout  | 30 seconds
 
 *** Variables ***
-| ${broker.uri}     | mqtt.eclipse.org
+| ${broker.uri}     | 127.0.0.1
 | ${broker.port}    | 1883
 | ${client.id}      | mqtt.test.client
 | ${topic}          | test/mqtt_test

--- a/tests/pubsub.robot
+++ b/tests/pubsub.robot
@@ -22,7 +22,6 @@
 | | Subscribe to MQTT Broker and Validate       | client.id=${client}   | topic=${topic}        | message=${message}
 
 | Publish multiple messages and confirm that validation succeeds only after correct message is published
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -39,7 +38,6 @@
 | | Subscribe to MQTT Broker and Validate       | client.id=${client}   | topic=${topic}        | message=${message}
 
 | Publish an empty message with QOS 1 and validate
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -49,7 +47,6 @@
 | | Subscribe to MQTT Broker and Validate       | client.id=${client}     | topic=${topic}
 
 | Publish and validate with regular expression
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -61,7 +58,6 @@
 | | Subscribe to MQTT Broker and Validate       | client.id=${client}   | topic=${topic}        | message=${regex}
 
 | Subscribe for the first time and validate that no messages are received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -70,7 +66,6 @@
 | | Length Should Be    | ${messages}   | 0
 
 | Subscribe, publish 1 message and validate it is received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -82,7 +77,6 @@
 | | Should Be Equal As Strings  | ${messages}[0]    | test message
 
 | Subscribe with no limit, publish multiple messages and validate they are received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -98,7 +92,6 @@
 | | Should Be Equal As Strings  | ${messages}[2]    | test message3
 
 | Subscribe with limit
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -117,7 +110,6 @@
 | | Should Be Equal As Strings  | ${messages}[1]    | test message3
 
 | Unsubscribe and validate no messages are received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
@@ -137,12 +129,12 @@
 | | ${message}  | Set Variable  | subscription test message
 | | Set username and password   | authuser1     | password1
 | | Run Keyword And Expect Error                | The expected payload didn't arrive in the topic
-| | ... | Subscribe to MQTT Broker and Validate | broker.uri=127.0.0.1  | client.id=${client}
+| | ... | Subscribe to MQTT Broker and Validate | broker.uri=127.0.0.1  | port=11883    | client.id=${client}
 | | ... | topic=${topic}        | message=${message}
-| | Connect     | 127.0.0.1
+| | Connect     | 127.0.0.1     | 11883
 | | Publish     | ${topic}      | test message with username and password   | qos=1
 | | Subscribe to MQTT Broker and Validate
-| | ...         | broker.uri=127.0.0.1  | client.id=${client}   | topic=${topic}        | message=test message with username and password
+| | ...         | broker.uri=127.0.0.1  | port=11883    | client.id=${client}   | topic=${topic}        | message=test message with username and password
 | | [Teardown]  | Disconnect
 
 | Publish to a broker that requires authentication with invalid password
@@ -152,17 +144,15 @@
 | | ${topic}    | Set Variable  | test
 | | Set username and password   | authuser1     | invalidpwd
 | | Run Keyword and expect error    | The client disconnected unexpectedly
-| | ...         | Connect     | 127.0.0.1     | 1883          | ${client}
+| | ...         | Connect     | 127.0.0.1     | 11883          | ${client}
 | | [Teardown]  | Disconnect
 
 | Subscribe async, publish 1 message, listen for and validate it is received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
 | | Subscribe Async | client.id=${client}   | topic=${topic}
 | | Publish to MQTT Broker   | topic=${topic}    | message=test message      | qos=1
-| | Sleep       | 5s
 | | @{messages} | Listen and Get Messages    | topic=${topic}
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 1
@@ -170,17 +160,13 @@
 | | [Teardown]  | Unsubscribe and Disconnect  | ${topic}
 
 | Subscribe async, publish several messages, listen for and validate they are received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client}   | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${topic}    | Set Variable  | test/mqtt_test_sub
 | | Subscribe Async | client.id=${client}   | topic=${topic}
 | | Publish to MQTT Broker   | topic=${topic}    | message=test message1      | qos=1
-| | Sleep       | 1s
 | | Publish to MQTT Broker   | topic=${topic}    | message=test message2      | qos=1
-| | Sleep       | 1s
 | | Publish to MQTT Broker   | topic=${topic}    | message=test message3      | qos=1
-| | Sleep       | 5s
 | | @{messages} | Listen and Get Messages    | topic=${topic} | limit=0
 | | LOG         | ${messages}
 | | Length Should Be            | ${messages}       | 3
@@ -190,7 +176,6 @@
 | | [Teardown]  | Unsubscribe and Disconnect  | ${topic}
 
 | Subscribe async to multiple topics, publish several messages, listen for them and validate they are received
-| | Sleep       | 1s
 | | ${time}     | Get Time      | epoch
 | | ${client1}  | Catenate      | SEPARATOR=.   | robot.mqtt | ${time}
 | | ${client2}  | Catenate      | SEPARATOR=.   | robot.mqtt | ${time+1}
@@ -199,11 +184,8 @@
 | | Subscribe Async | client.id=${client1}   | topic=${topic1}
 | | Subscribe Async | client.id=${client2}   | topic=${topic2}
 | | Publish to MQTT Broker   | topic=${topic2}    | message=test message1      | qos=1
-| | Sleep       | 1s
 | | Publish to MQTT Broker   | topic=${topic1}    | message=test message2      | qos=1
-| | Sleep       | 1s
 | | Publish to MQTT Broker   | topic=${topic2}    | message=test message3      | qos=1
-| | Sleep       | 5s
 | | @{messages1} | Listen and Get Messages    | topic=${topic1} | limit=0
 | | @{messages2} | Listen and Get Messages    | topic=${topic2} | limit=0
 | | LOG         | ${messages1}


### PR DESCRIPTION
Remove usage of public eclipse broker for tests. This requires launching 2 brokers locally, one without auth and other with. 

Fixes #21 