### PR TITLE
Changed library to use background loop instead of manually looping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
 - '3.7'
 before_install:
 - docker pull eclipse-mosquitto
-- docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
-- docker run -d -p 1883:1883 eclipse-mosquitto
+- docker run -d -p 1883:1883 -v $(pwd)/mosquitto/mosquitto-no-passwd.conf:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+- docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf -v $(pwd)/mosquitto/passwd_file:/mosquitto/config/passwd_file eclipse-mosquitto
 install:
 - pip install -r requirements.txt
 script:

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ The keywords in this library are based on some of the methods available in eclip
 The tests are in ``tests`` folder and make use of Robot Framework itself. They are run automatically through travis when code is pushed to a branch. When run locally, these tests rely on locally running mqtt brokers. We need 2 running brokers, one without auth that is used by most of the tests, and the other one with auth (configuration file is provided). You'll need to start them before running the tests. You can then run the tests locally::
 
     docker pull eclipse-mosquitto
-    docker run -d -p 1883:1883 eclipse-mosquitto
-    docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto:/mosquitto/config eclipse-mosquitto
+    docker run -d -p 1883:1883 -v $(pwd)/mosquitto/mosquitto-no-passwd.conf:/mosquitto/config/mosquitto.conf eclipse-mosquitto
+    docker run -d -p 11883:1883 -p 9001:9001 -v $(pwd)/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf -v $(pwd)/mosquitto/passwd_file:/mosquitto/config/passwd_file eclipse-mosquitto
     robot -P src tests
 
 

--- a/mosquitto/mosquitto-no-passwd.conf
+++ b/mosquitto/mosquitto-no-passwd.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,2 +1,3 @@
 allow_anonymous false
-password_file ./mosquitto/config/passwd_file
+password_file /mosquitto/config/passwd_file
+listener 1883


### PR DESCRIPTION
# Addresses #25 

This pull requests tries to fix problems with mqtt broker suddenly disconnecting. #4 thinks it might be related to looping mechanism somehow not working properly with robot.

## Changes
- Changed looping mechanism to be background looping with `self._mqttc.loop_start()` and `self._mqttc.loop_stop()`
- Fixed mosquitto test case documentation + added conf
    - Since mosquitto 2.0 auth mechanism is required to specify https://mosquitto.org/documentation/authentication-methods/

## TODO

Some pub/sub test cases are still failing. This is caused by them being synchronous.

Example: 

Test case `Publish a message with QOS 1 and validate that the message is received` first sends a message to broker and reconnects, subscribes and tries to receive it. Due to this case using synchronous `Subscribe And Validate` message which was sent before has already timed out and cannot be received.


