### PR TITLE
Migrate to paho-mqtt 2

### DIFF
--- a/src/MQTTLibrary/MQTTKeywords.py
+++ b/src/MQTTLibrary/MQTTKeywords.py
@@ -68,7 +68,9 @@ class MQTTKeywords(object):
         logger.info('Connecting to %s at port %s' % (broker, port))
         self._connected = False
         self._unexpected_disconnect = False
-        self._mqttc = mqtt.Client(client_id, clean_session)
+        self._mqttc = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION1, client_id, clean_session
+        )
 
         # set callbacks
         self._mqttc.on_connect = self._on_connect


### PR DESCRIPTION
* addressing breaking change documented on https://github.com/eclipse/paho.mqtt.python/blob/master/docs/migrations.rst#versioned-the-user-callbacks